### PR TITLE
Fix: Avoidance Area Report Modal X Button obstruction

### DIFF
--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -246,7 +246,7 @@ const ReportModal = ({
           </View>
 
           {/* Heading and subheading */}
-          <View className="flex-1">
+          <View className="flex-1 pr-8">
             {currentStep === 1 ? (
               <Controller
                 control={control}


### PR DESCRIPTION
## Feature Description

The X button for the Avoidance Area report was unclickable.

- **Problem**: Headings and subheadings obstructed the clickable region for the X button.
- **Solution**: Add padding to the right side of the headings and subheadings container to ensure the X button clickable region is unobstructed

## Demos

The line UI element below the text input serves as a visual indicator of the obstruction by the heading and subheading container.

### Before
<img width="276" height="87" alt="Obstructed-X-Button" src="https://github.com/user-attachments/assets/c5e6ab04-3c73-46e6-9ccb-9f661dac92c5" />

### After
<img width="275" height="90" alt="Unobstructed-X-Button" src="https://github.com/user-attachments/assets/667ff607-5d58-4a69-87a5-f9f86f248072" />